### PR TITLE
Server now checks if task exists before updating

### DIFF
--- a/server/samplereq.json
+++ b/server/samplereq.json
@@ -1,5 +1,5 @@
 {
-  "id": "1default-task-uuid-wasp-twelvecharss",
+  "id": "123e4567-e89b-12d3-a456-426614174000",
   "title": "Requested added task",
   "description": "Description for the added task.",
   "code": "alert(1);"

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -60,7 +60,7 @@ app.post("/task", (req, res) => {
 }); //Add one task (JSON: request contains title, description and code, response contains id, title, description and code)
 
 app.put("/task", (req, res) => {
-  if (req.body.title && req.body.description && req.body.code) {
+  if (req.body.title && req.body.description && req.body.code && req.body.id in tasks) {
     const upTask: Task = {
       id: req.body.id,
       title: req.body.title,


### PR DESCRIPTION
The server now checks if a task with the specified id exists before setting the value. This prevents anyone from creating a task using the update functionality and manually setting the id.