### PR TITLE
Evan export/import srv

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -57,6 +57,7 @@ const help: string = `
 HELP              Shows this help screen.
 EXPORT <FILEPATH> Exports the tasklist to the specified file. (JSON)
 IMPORT <FILEPATH> Imports the tasklist from the specified file. (JSON)
+CTRL + C          Stops the server.
 `;
 const typeHelp: string = " Type 'help' to get more information.";
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from "uuid";
 import cors from "cors";
 import { sha512 } from "js-sha512";
 import fs from "fs";
+import readline from "readline";
 
 const app = express();
 const port: number = 3000;
@@ -59,12 +60,14 @@ EXPORT <FILEPATH> Exports the tasklist to the specified file.
 const typeHelp: string = " Type 'help' to get more information.";
 
 function cmdLoop(): void {
-  const readline = require("readline").createInterface({
+  const r = readline.createInterface({
     input: process.stdin,
-    output: process.stdout
+    output: process.stdout,
+    prompt: "WASP> "
   });
-  readline.question("WASP> ", (cmd: string): void => {
-    const cmdArgs: Array<string> = cmd.split(" ");
+  r.prompt();
+  r.on("line", (cmd: string): void => {
+    const cmdArgs: Array<string> = cmd.trim().split(" ");
     switch (cmdArgs[0].toLowerCase()) {
       case "export":
         if (!cmdArgs[1]) {
@@ -89,8 +92,10 @@ function cmdLoop(): void {
       default:
         console.log("Unknown command '" + cmd + "'." + typeHelp);
     }
-    readline.close();
-    cmdLoop();
+    r.prompt();
+  }).on("close", () => {
+    console.log("Have a great day!");
+    process.exit(0);
   });
 }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -79,6 +79,7 @@ function cmdLoop(): void {
         break;
       case "help":
         console.log(help);
+        break;
       default:
         console.log("Unknown command '" + cmd + "'." + typeHelp);
     }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -71,6 +71,12 @@ function cmdLoop(): void {
           console.error("Please specify the output file path." + typeHelp);
           break;
         }
+        if (/[<>:"|?*]/i.test(cmdArgs[1])) {
+          console.error(
+            "A filepath can't contain any of the following characters:\n: * ? \" < > | "
+          );
+          break;
+        }
         const data: string = JSON.stringify(tasks);
         fs.writeFile(cmdArgs[1], data, (err: NodeJS.ErrnoException): void => {
           if (err) console.error("\nError!\n" + err);

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -66,7 +66,7 @@ function cmdLoop(): void {
     prompt: "WASP> "
   });
   r.prompt();
-  r.on("line", (cmd: string): void => {
+  r.on("line", async (cmd: string): Promise<void> => {
     const cmdArgs: Array<string> = cmd.trim().split(" ");
     switch (cmdArgs[0].toLowerCase()) {
       case "export":
@@ -81,13 +81,19 @@ function cmdLoop(): void {
           break;
         }
         const data: string = JSON.stringify(tasks);
-        fs.writeFile(cmdArgs[1], data, (err: NodeJS.ErrnoException): void => {
-          if (err) console.error("\nError!\n" + err);
-          else console.log("Tasks exported successfully!");
-        });
+        await fs.promises
+          .writeFile(cmdArgs[1], data)
+          .then((): void => {
+            console.log("Tasks exported successfully!");
+          })
+          .catch((err: NodeJS.ErrnoException): void => {
+            console.error(err);
+          });
         break;
       case "help":
         console.log(help);
+        break;
+      case "":
         break;
       default:
         console.log("Unknown command '" + cmd + "'." + typeHelp);


### PR DESCRIPTION
### Description
> Adds a simple CLI to the wasp server with 'export' and 'help' commands. It is possible to easily add commands to the system, like an import system for example.

### References
> - https://nodejs.org/api/fs.html
> - https://nodejs.org/api/readline.html
> - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON

### Testing
> Run the server. Type any command. Follow the steps. Write a lot of wrong input to test error handling.
> Add some tasks, export them. Restart the server. Import the tasks.

resolves #49 

## EDIT
I also added the import functionality as it was very easy and quick and I thought I would forget how to do it later.

resolves #50 